### PR TITLE
Added a --secure-origin option

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,6 +18,7 @@ const cli = meow(`
   Options
     --help                            Show this help.
     --inspect                         Run in actual Chrome window and keep it open.
+    --secure-origin                   Give the Chrome page a secure origin
     --p <port>, --port <port>         Serve on this port. Defaults to random port.
     --serve <./file>[:</serve/here>]  Serve additional files next to bundle.
 
@@ -64,6 +65,7 @@ async function run () {
   const entrypoint = process.argv[firstArgumentIndex]
 
   const headless = runnerOptionArgs.indexOf("--inspect") > -1 ? false : true
+  const secureOrigin = runnerOptionArgs.indexOf("--secure-origin") > -1
   const port = runnerOptions.p || runnerOptions.port
     ? parseInt(runnerOptions.p || runnerOptions.port, 10)
     : await getPort()
@@ -84,7 +86,7 @@ async function run () {
 
     const { bundle, server } = await serveBundle(scriptPaths, temporaryCache, port)
     await copyFiles(additionalFilesToServe, temporaryCache)
-    const puppet = await spawnPuppet(bundle, serverURL, { headless })
+    const puppet = await spawnPuppet(bundle, serverURL, { headless, secureOrigin })
     await puppet.run(scriptArgs, plugin)
 
     exitCode = await puppet.waitForExit()

--- a/src/puppeteer.ts
+++ b/src/puppeteer.ts
@@ -109,7 +109,7 @@ function createExitPromise (page: Page) {
   })
 }
 
-export async function spawnPuppet (bundle: ParcelBundle, serverURL: string, options: { headless?: boolean }): Promise<Puppet> {
+export async function spawnPuppet(bundle: ParcelBundle, serverURL: string, options: { headless?: boolean, secureOrigin?: boolean }): Promise<Puppet> {
   const { headless = true } = options
 
   const browser = await launch({
@@ -118,6 +118,12 @@ export async function spawnPuppet (bundle: ParcelBundle, serverURL: string, opti
   })
 
   const [ page ] = await browser.pages()
+
+  if (options.secureOrigin) {
+    // https://github.com/GoogleChrome/puppeteer/issues/2301
+    await page.goto("file:///")
+  }
+
   let puppetExit: Promise<number>
 
   capturePuppetConsole(page)

--- a/src/script-error.ts
+++ b/src/script-error.ts
@@ -1,9 +1,9 @@
 // tslint:disable-next-line
-interface ScriptError extends Error {}
+interface ScriptError extends Error { }
 
 // tslint:disable-next-line:no-shadowed-variable
-const ScriptError = function ScriptError (this: ScriptError, error: Error, stack?: string) {
-  Error.call(this, error)
+const ScriptError = function ScriptError(this: ScriptError, error: Error, stack?: string) {
+  Error.call(this, <any>error)
   Object.defineProperty(this, "message", {
     enumerable: false,
     value: error.message
@@ -12,7 +12,7 @@ const ScriptError = function ScriptError (this: ScriptError, error: Error, stack
     enumerable: false,
     value: stack || error.stack
   })
-} as any as { new (error: Error, stack?: string): ScriptError }
+} as any as { new(error: Error, stack?: string): ScriptError }
 
 ScriptError.prototype = new Error()
 ScriptError.prototype.name = "ScriptError"


### PR DESCRIPTION
Currently scripts are run in a page from an insecure origin which means that features such as `window.crypto.subtle` (and surely many more things) are not enabled.  This PR adds a `--secure-origin` command line option which implements the solution/hack at https://github.com/GoogleChrome/puppeteer/issues/2301.