### PR TITLE
Fix bug where files to serve would also be run directly

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -100,7 +100,7 @@ async function run() {
   )
   const additionalFilesToServe = await resolveDirectoryEntrypoints(ensureArray(runnerOptions.serve).map(parseEntrypointArg))
 
-  const entrypointArgs = runnerOptionArgs.filter(arg => arg.charAt(0) !== "-")
+  const entrypointArgs = runnerOptions._
   const entrypoints = await resolveEntrypoints(plugins, entrypointArgs.map(parseEntrypointArg), scriptArgs)
 
   const temporaryCache = createTemporaryFileCache()


### PR DESCRIPTION
Example: `puppet-run --serve ./some/web-worker.js entrypoint.html` did not only serve `./some/web-worker.js`, but also added a `<script>` for it, too.